### PR TITLE
PR作成時の一時ファイル使用を義務化

### DIFF
--- a/.aicoding/rules/002-execute-github-issue.yaml
+++ b/.aicoding/rules/002-execute-github-issue.yaml
@@ -365,6 +365,12 @@ development_tools_integration:
     issue_comment: "gh issue comment [issue_number] --body-file [temp_file_path]"
     issue_close: "gh issue close [issue_number] --comment [completion_message]"
     pr_creation: "gh pr create --title [title] --body-file [temp_file_path] --base main --head [branch]"
+    pr_creation_rules:
+      - "PRのタイトルとボディは必ず一時ファイルを使用"
+      - "改行文字を含む場合は--body-fileオプションを使用"
+      - "一時ファイルは/tmp/ghwt-pr-body-{timestamp}.txtに作成"
+      - "PR作成後に一時ファイルを削除"
+      - "コマンドライン引数での--bodyオプションは使用禁止"
     
   git_workflow:
     branch_creation: "git checkout -b feature/issue-{issue_number}-{sanitized_title}"
@@ -398,6 +404,12 @@ development_tools_integration:
       issue_comment: "/tmp/ghwt-issue-comment-{timestamp}.txt"
       commit_message: "/tmp/ghwt-commit-message-{timestamp}.txt"
     cleanup_policy: "操作完了後に即座に削除"
+    pr_creation_workflow:
+      step1: "PR本文を一時ファイルに書き込み"
+      step2: "gh pr create --title [title] --body-file [temp_file] を実行"
+      step3: "PR作成成功後に一時ファイルを削除"
+      step4: "エラー時も一時ファイルをクリーンアップ"
+      mandatory_usage: "改行を含むPR本文は必ず一時ファイル経由で作成"
     
   cursor_windsurf_integration:
     parallel_development: "複数のファイルやコンポーネントを同時に編集"
@@ -435,6 +447,12 @@ automation_settings:
     auto_assign_reviewers: false
     trigger: "after_commit"
     method: "body_file_option"
+    implementation_rules:
+      - "PR本文は必ず一時ファイルに作成"
+      - "gh pr create --body-file オプションを使用"
+      - "コマンドライン引数での--bodyは使用禁止"
+      - "改行文字の問題を回避するため一時ファイル必須"
+      - "作成後に一時ファイルを自動削除"
     
   auto_issue_close:
     enabled: false  # デフォルトは無効、人間の確認を推奨
@@ -464,6 +482,7 @@ collaboration_patterns:
       - "進捗状況の追跡と報告"
       - "技術的問題の初期分析"
       - "一時ファイルの管理とクリーンアップ"
+      - "PR作成時の一時ファイル使用による改行問題の回避"
       
     human_responsibilities:
       - "作業完了後の品質レビュー"
@@ -481,6 +500,7 @@ collaboration_patterns:
       - "ブランチ作成とチェックボックス更新"
       - "一時ファイルの作成・削除"
       - "コミット・PR作成の技術的手法"
+      - "PR作成時の一時ファイル使用判断（改行を含む場合は必須）"
       
     collaborative_decisions:
       - "作業完了の品質確認（必須レビュー）"


### PR DESCRIPTION
## 概要

仕様書間の不整合を修正し、全ドキュメントの日付を統一しました。

## 修正内容

### 1. 日付の統一
- 全仕様書の日付を2025-06-01に統一
- 要件定義書、CLI仕様書、設定ファイル仕様書、エラーハンドリング仕様書

### 2. 設定ファイル構造の統一
- 要件定義書の設定ファイルスキーマを最新仕様に合わせて修正
- 削除: `[git]`セクション、`[ui]`セクション
- 保持: `[core]`セクションのみ（シンプル構成）

### 3. データ構造の統一
- 要件定義書のデータ構造記述を最新仕様に合わせて修正
- 削除: `GitOperationResult`、`GitConfig`、`UiConfig`構造体
- 追加: `SerializationError`、`NetworkError`、`PermissionError`
- 詳細化: `Repository`、`Worktree`構造体のフィールド説明

### 4. ルール更新
- PR作成時の一時ファイル使用を義務化
- 改行文字問題の解決策を明記

## 整合性確認済み項目

- ✅ コマンド仕様（要件定義書 ↔ CLI仕様書）
- ✅ エラーコード体系（要件定義書 ↔ エラーハンドリング仕様書）
- ✅ JSON出力形式（データ構造仕様書 ↔ CLI仕様書）
- ✅ 設定管理（設定ファイル仕様書 ↔ 要件定義書）

## 関連Issue

Closes #4

## チェックリスト

- [x] 全仕様書間の不整合を確認・修正
- [x] 日付の統一（2025-06-01）
- [x] 設定ファイル構造の統一
- [x] データ構造の統一
- [x] コマンド仕様の整合性確認
- [x] エラーコード体系の整合性確認
- [x] PR作成ルールの更新（一時ファイル使用） 